### PR TITLE
Customizations

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,11 +14,13 @@ import (
 var envLabel *dto.LabelPair
 
 func main() {
+	log.Print("Starting promproxy")
+
 	if env, ok := os.LookupEnv("PROMPROXY_ENV_LABEL"); ok {
 		envLabel = util.CreateLabelPair("env", env)
+		log.Print("Using environment label " + env)
 	}
 
-	log.Print("Starting promproxy")
 	http.HandleFunc("/", reqHandler)
 	log.Fatal(http.ListenAndServe(":9999", nil))
 }

--- a/main.go
+++ b/main.go
@@ -27,8 +27,16 @@ func main() {
 		log.Print("Expecting access token " + token)
 	}
 
+	var port string
+	if configPort, ok := os.LookupEnv("PROMPROXY_PORT"); ok {
+		port = ":" + configPort
+	} else {
+		port = ":9999"
+	}
+	log.Print("Listening on port ", port)
+
 	http.HandleFunc("/", reqHandler)
-	log.Fatal(http.ListenAndServe(":9999", nil))
+	log.Fatal(http.ListenAndServe(port, nil))
 }
 
 func reqHandler(w http.ResponseWriter, inReq *http.Request) {


### PR DESCRIPTION
Allow the project to be customizable by the user via environment variables.

In particular, allow to require an `Authorization: Bearer` token for the requests, and specifying the port on which to hear.